### PR TITLE
feat: Se habilita la excepción de los permisos de home para determinados usuarios

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ También el rol permite que se sobrescriban otras variables para adaptarse a las
 * grupos_innecesarios. Lista de grupos que no han de existir en la máquina.
 * shell_usuarios_especificos. Lista de usuarios específicos con UID a los que asignar una shell en concreto diferente de bash.
 * demonios_y_procesos_innecesarios. Demonios y procesos que no son necesarios en la máquina o grupos de máquinas.
+* permisos_home_usuarios_especificos. Usuarios con UID>1000 sobre los que no aplicar los permisos de home indicados en la guía.
 
 
 A la hora de ejecutar el rol habrá que indicar el nivel de categoría del ENS que han de cumplir los hosts donde se aplicará el bastionado. Ejemplo:

--- a/defaults/main/limites_permisos_y_cad_claves.yml
+++ b/defaults/main/limites_permisos_y_cad_claves.yml
@@ -1,0 +1,4 @@
+permisos_home_usuarios_especificos:
+  - sophos-spl-user
+  - sophos-spl-local
+  - sophos-spl-updatescheduler

--- a/tasks/limites_permisos_y_cad_claves.yml
+++ b/tasks/limites_permisos_y_cad_claves.yml
@@ -97,3 +97,4 @@
     state: directory
     mode: "g-wx,o-rwx"
   with_items: "{{ users_home_list.results }}"
+  when: item.item not in (permisos_home_usuarios_especificos | default([], true))


### PR DESCRIPTION
Se habilita la opción de definir mediante una variable una lista de usuarios a los que no aplicar los permisos de home especificados en la guía. Se pone como ejemplo los usuarios del Sophos, pero esta variable puede ser sobrescrita para cubrir las necesidades de caso.