### PR TITLE
feat: Se exceptua también el cambio de shell de ciertos usuarios deja…

### DIFF
--- a/defaults/main/limites_permisos_y_cad_claves.yml
+++ b/defaults/main/limites_permisos_y_cad_claves.yml
@@ -2,3 +2,5 @@ permisos_home_usuarios_especificos:
   - sophos-spl-user
   - sophos-spl-local
   - sophos-spl-updatescheduler
+  - sophos-spl-av
+  - sophos-spl-threat-detector

--- a/defaults/main/usuarios_innecesarios.yml
+++ b/defaults/main/usuarios_innecesarios.yml
@@ -26,4 +26,8 @@ shell_usuarios:
   - { user: 'halt', shell: '/sbin/halt' }
 
 shell_usuarios_especificos:
-#  - { user: 'usuario_especifico', shell: '/sbin/nologin'}
+  - { user: 'sophos-spl-user', shell: '/bin/false' }
+  - { user: 'sophos-spl-local', shell: '/bin/false' }
+  - { user: 'sophos-spl-updatescheduler', shell: '/bin/false' }
+  - { user: 'sophos-spl-av', shell: '/bin/false' }
+  - { user: 'sophos-spl-threat-detector', shell: '/bin/false' }

--- a/tasks/limites_permisos_y_cad_claves.yml
+++ b/tasks/limites_permisos_y_cad_claves.yml
@@ -86,6 +86,7 @@
 - name: Obtener los directorios home de los usuarios con UID > 1000
   ansible.builtin.command: "awk -F: -v user={{ item }} '$1==user {print $6}' /etc/passwd"
   loop: "{{ users_list.stdout_lines }}"
+  when: item not in (permisos_home_usuarios_especificos | default([], true))
   register: users_home_list
   changed_when: false
   check_mode: false
@@ -97,4 +98,4 @@
     state: directory
     mode: "g-wx,o-rwx"
   with_items: "{{ users_home_list.results }}"
-  when: item.item not in (permisos_home_usuarios_especificos | default([], true))
+  when: item.stdout is defined

--- a/tasks/usuarios_innecesarios.yml
+++ b/tasks/usuarios_innecesarios.yml
@@ -30,6 +30,7 @@
     - 619B_Reiniciar_host
 
 - name: Asignando shell a usuarios root, shutdown y halt
+  become: true
   ansible.builtin.user:
     name: "{{ item.user }}"
     shell: "{{ item.shell }}"
@@ -58,7 +59,11 @@
     name: "{{ item.user }}"
     shell: "{{ item.shell }}"
   with_items: "{{ shell_usuarios_especificos }}"
-  when: shell_usuarios_especificos is defined and shell_usuarios_especificos != None
+  when:
+    - shell_usuarios_especificos is defined
+    - shell_usuarios_especificos != None
+    - item.user in usuarios_normales.stdout_lines
+    - item.shell
   notify:
     - 619B_Reiniciar_host
 


### PR DESCRIPTION
…ndo la que tenga

Se añade la opción de exceptuar el cambio de shell sin tener que fijar una específica, permitiendo que mantengan la que ya tengan asignada. Se soluciona un error al exceptuar home de usuarios específicos de fijar los permisos indicados por la guía. Se añaden otros usuarios de Sophos a exceptuar